### PR TITLE
Add ManyLinux2014 tags and update 3RDPARTY_VERSION

### DIFF
--- a/Dockerfile-manylinux1_i686
+++ b/Dockerfile-manylinux1_i686
@@ -1,0 +1,16 @@
+FROM quay.io/pypa/manylinux1_i686:latest
+
+COPY build_scripts/build_tools.sh build_scripts/build_3rdparty_static.sh ./
+
+RUN /build_tools.sh && rm -r /build_tools.sh
+
+ENV PATH /usr/lib/qt4/bin:/usr/local/cmake-2.8.12/bin:${PATH}
+ENV PATH /opt/python/cp27-cp27mu/bin/:${PATH}
+
+ENV PREFIX /usr/local
+ENV PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+ENV ESSENTIA_3RDPARTY_VERSION v2.1_beta5-46-g896a402f
+
+RUN /build_3rdparty_static.sh && rm -r /build_3rdparty_static.sh
+
+CMD ["/bin/bash"]

--- a/Dockerfile-manylinux1_x86_64
+++ b/Dockerfile-manylinux1_x86_64
@@ -9,7 +9,7 @@ ENV PATH /opt/python/cp27-cp27mu/bin/:${PATH}
 
 ENV PREFIX /usr/local
 ENV PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
-ENV ESSENTIA_3RDPARTY_VERSION v2.1_beta4-447-gc5ea273
+ENV ESSENTIA_3RDPARTY_VERSION v2.1_beta5-46-g896a402f
 
 RUN /build_3rdparty_static.sh && rm -r /build_3rdparty_static.sh
 

--- a/Dockerfile-manylinux2014_i686
+++ b/Dockerfile-manylinux2014_i686
@@ -1,0 +1,16 @@
+FROM quay.io/pypa/manylinux2014_i686:latest
+
+COPY build_scripts/build_tools.sh build_scripts/build_3rdparty_static.sh ./
+
+RUN /build_tools.sh && rm -r /build_tools.sh
+
+ENV PATH /usr/lib/qt4/bin:/usr/local/cmake-2.8.12/bin:${PATH}
+ENV PATH /opt/python/cp27-cp27mu/bin/:${PATH}
+
+ENV PREFIX /usr/local
+ENV PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+ENV ESSENTIA_3RDPARTY_VERSION v2.1_beta5-46-g896a402f
+
+RUN /build_3rdparty_static.sh && rm -r /build_3rdparty_static.sh
+
+CMD ["/bin/bash"]

--- a/Dockerfile-manylinux2014_x86_64
+++ b/Dockerfile-manylinux2014_x86_64
@@ -1,15 +1,15 @@
-FROM quay.io/pypa/manylinux1_i686:latest
+FROM quay.io/pypa/manylinux2014_x86_64:latest
 
 COPY build_scripts/build_tools.sh build_scripts/build_3rdparty_static.sh ./
 
 RUN /build_tools.sh && rm -r /build_tools.sh
 
-ENV PATH /usr/lib/qt4/bin:/usr/local/cmake-2.8.12/bin:${PATH}
+ENV PATH /usr/lib64/qt4/bin:/usr/local/cmake-2.8.12/bin:${PATH}
 ENV PATH /opt/python/cp27-cp27mu/bin/:${PATH}
 
 ENV PREFIX /usr/local
 ENV PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
-ENV ESSENTIA_3RDPARTY_VERSION v2.1_beta4-447-gc5ea273
+ENV ESSENTIA_3RDPARTY_VERSION v2.1_beta5-46-g896a402f
 
 RUN /build_3rdparty_static.sh && rm -r /build_3rdparty_static.sh
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
-for PLATFORM in "i686" "x86_64"; do
-    docker build --rm -t mtgupf/essentia-builds:manylinux1_$PLATFORM -f Dockerfile-$PLATFORM .
+for MANYLINUX in "1" "2014"; do
+    for PLATFORM in "i686" "x86_64"; do
+        docker build --rm -t mtgupf/essentia-builds:manylinux${MANYLINUX}_$PLATFORM -f Dockerfile-manylinux${MANYLINUX}_$PLATFORM .
+    done
 done

--- a/build_scripts/build_tools.sh
+++ b/build_scripts/build_tools.sh
@@ -4,6 +4,7 @@ YASM_VERSION=yasm-1.3.0
 CMAKE_VERSION=cmake-2.8.12
 
 # yasm on CentOS 5 is too old, install a newer version
+# manylinux2014(CentOS 7) has yasm-1.2.0 by default. Is it enough?
 curl -SLO http://www.tortall.net/projects/yasm/releases/$YASM_VERSION.tar.gz
 tar -xvf $YASM_VERSION.tar.gz
 cd $YASM_VERSION
@@ -15,6 +16,9 @@ rm -r $YASM_VERSION $YASM_VERSION.tar.gz
 
 # cmake is also too old
 # taglib requires CMake 2.8.0, chromaprint requires CMake 2.8.12
+# in manylinux2014(CentOS 7) yum installs CMake 2.8.12.2 by default
+# we could use that instead of compiling when the manylinux1 support is
+# dropped
 curl -SLO http://www.cmake.org/files/v2.8/$CMAKE_VERSION.tar.gz
 tar -xvf $CMAKE_VERSION.tar.gz
 cd $CMAKE_VERSION


### PR DESCRIPTION
- The 3RDPARTY_VERSION update adds the Eigen library
- The ManyLinux2014 tag will be used to build the wheels for Essentia with Tensorflow (`essentia-tensorflow`) for now. Regular Essentia wheels will keep beeing built on the ManyLinux1.